### PR TITLE
Add Roboto Condensed/Slab font support

### DIFF
--- a/generate_qr_badges_final.py
+++ b/generate_qr_badges_final.py
@@ -104,7 +104,7 @@ WHITE = '#FFFFFF'
 GT_HOVER = '#D4C58C'  # lighter gold for hover
 
 # Preferred font stack
-PREFERRED_FONT = 'Roboto'
+PREFERRED_FONT = ['Roboto Condensed', 'Roboto Slab', 'Roboto']
 FALLBACK_FONTS = ['Helvetica', 'Arial']
 
 DEFAULT_CONFIG = {
@@ -129,8 +129,10 @@ REQUIRED_CSV_COLUMNS = [
 
 def _choose_font(root):
     available = set(tkfont.families(root))
-    if PREFERRED_FONT in available:
-        return (PREFERRED_FONT, 12)
+    preferred = PREFERRED_FONT if isinstance(PREFERRED_FONT, (list, tuple)) else [PREFERRED_FONT]
+    for pf in preferred:
+        if pf in available:
+            return (pf, 12)
     for fb in FALLBACK_FONTS:
         if fb in available:
             return (fb, 12)


### PR DESCRIPTION
## Summary
- extend preferred font list with Roboto Condensed and Roboto Slab
- check for each preferred font before falling back

## Testing
- `python3 -m py_compile generate_qr_badges_final.py`

------
https://chatgpt.com/codex/tasks/task_e_68449e1061bc8332a4b5c04cbc762d0e