### PR TITLE
Fix macOS build arch handling

### DIFF
--- a/QR_Badges_mac.spec
+++ b/QR_Badges_mac.spec
@@ -29,7 +29,8 @@ exe = EXE(
     console=False,
     disable_windowed_traceback=False,
     argv_emulation=False,
-    target_arch="universal2",
+    # build for current Python architecture
+    target_arch=None,
     codesign_identity=None,
     entitlements_file=None,
     icon=['AppIcon.icns'],

--- a/README.md
+++ b/README.md
@@ -70,11 +70,15 @@ The output Word document will be created alongside your input CSV.
 ## Building Standalone Apps
 
 PyInstaller spec files are provided for macOS (`QR_Badges_mac.spec`) and Windows (`QR_Badges_win.spec`).
+If your Python environment is single-arch, use the macOS spec as-is (or set
+`target_arch` to `arm64` or `x86_64`) and run:
+
+```bash
+# macOS build (single-arch)
+pyinstaller QR_Badges_mac.spec
+```
 
 ```
-# macOS universal build
-pyinstaller QR_Badges_mac.spec
-
 # Windows build
 pyinstaller QR_Badges_win.spec
 ```


### PR DESCRIPTION
## Summary
- build the macOS executable for the active Python architecture
- update build instructions for single-arch environments

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6844aae36c508332bbf100ae4890d03b