### PR TITLE
Add workflow to build distributable apps

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,48 @@
+name: Build QR Badges
+
+on:
+  push:
+    tags:
+      - 'v*'
+  workflow_dispatch:
+
+jobs:
+  macos:
+    runs-on: macos-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-python@v4
+        with:
+          python-version: '3.x'
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements.txt pyinstaller
+      - name: Build macOS app
+        run: pyinstaller QR_Badges_mac.spec
+      - name: Create DMG
+        run: hdiutil create -volname "QR Badges" -srcfolder "dist/QR Badges.app" QR_Badges.dmg
+      - uses: actions/upload-artifact@v3
+        with:
+          name: qr-badges-macos
+          path: QR_Badges.dmg
+
+  windows:
+    runs-on: windows-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-python@v4
+        with:
+          python-version: '3.x'
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements.txt pyinstaller
+      - name: Build Windows exe
+        run: pyinstaller QR_Badges_win.spec
+      - name: Compress build
+        run: Compress-Archive -Path dist/QR_Badges -DestinationPath QR_Badges.zip
+      - uses: actions/upload-artifact@v3
+        with:
+          name: qr-badges-windows
+          path: QR_Badges.zip

--- a/README.md
+++ b/README.md
@@ -85,6 +85,10 @@ pyinstaller QR_Badges_win.spec
 
 Each build produces a standalone application bundle. macOS users can create a DMG using `hdiutil` after running the spec.
 
+## GitHub Actions Build
+
+A workflow file at `.github/workflows/build.yml` automates these steps. When you push a tag (e.g. `v3.6.1`) or run the workflow manually, GitHub Actions builds the macOS DMG and the Windows ZIP. The resulting artifacts are available for download from the workflow run.
+
 ---
 
 5z4xbu-codex/add-license-file-and-reference-in-readme


### PR DESCRIPTION
## Summary
- automate macOS and Windows builds with GitHub Actions
- mention the workflow in the README

## Testing
- `python3 -m py_compile generate_qr_badges_final.py`

------
https://chatgpt.com/codex/tasks/task_e_6844a2126e0c83328a7512906180de02