### PR TITLE
Fix MIT license text formatting

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,8 +1,5 @@
 MIT License
-
-5z4xbu-codex/add-license-file-and-reference-in-readme
 Copyright (c) 2025 R. Clark Myers, M.Ed.
-
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal


### PR DESCRIPTION
## Summary
- remove codex branch note from LICENSE
- ensure MIT license text begins right after the header

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_68484526d12083328bedc10773162d5d