### PR TITLE
Fix MIT license formatting

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,5 @@
 MIT License
 Copyright (c) 2025 R. Clark Myers, M.Ed.
-
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal
 in the Software without restriction, including without limitation the rights


### PR DESCRIPTION
## Summary
- remove stray blank line from `LICENSE`

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_684849d88c248332b6633942ce91831f