### PR TITLE
Add group inline with pronouns on name badges

### DIFF
--- a/generate_qr_badges_final.py
+++ b/generate_qr_badges_final.py
@@ -603,6 +603,7 @@ def name_badges_fixed(file_path: Path, save_path: Path, cfg: dict = DEFAULT_CONF
                 add_centered_paragraph(cs_text, font_size=11)
 
             group = safe_str(rec.get('Group Number', '')).strip()
+            group = f"Group: {group}" if group else ''
             pronouns = safe_str(rec.get('Pronouns', '')).strip()
             gp_text = ' – '.join(filter(None, [group, pronouns]))
             if gp_text:


### PR DESCRIPTION
## Summary
- show Group Number inline with pronouns in the student badge

## Testing
- `python3 -m py_compile generate_qr_badges_final.py`

------
https://chatgpt.com/codex/tasks/task_e_685581c0d2688332a35bb42f31426f0d