### PR TITLE
Add group inline with pronouns on name badges

### DIFF
--- a/QR_Badges_mac.spec
+++ b/QR_Badges_mac.spec
@@ -50,7 +50,7 @@ app = BUNDLE(
     icon='AppIcon.icns',
     bundle_identifier='com.example.qrbadges',
     info_plist={
-        'CFBundleShortVersionString': '3.6.1-postfix',
-        'CFBundleVersion': '3.6.1-postfix',
+        'CFBundleShortVersionString': '3.6.2',
+        'CFBundleVersion': '3.6.2',
     }
 )

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ Double-click **QR Badges.app** to launch.
 
 ## Version
 
-Current app version: **3.6.1-postfix**
+Current app version: **3.6.2**
 
 ## Updating
 
@@ -87,7 +87,7 @@ Each build produces a standalone application bundle. macOS users can create a DM
 
 ## GitHub Actions Build
 
-A workflow file at `.github/workflows/build.yml` automates these steps. When you push a tag (e.g. `v3.6.1`) or run the workflow manually, GitHub Actions builds the macOS DMG and the Windows ZIP. The resulting artifacts are available for download from the workflow run.
+A workflow file at `.github/workflows/build.yml` automates these steps. When you push a tag (e.g. `v3.6.2`) or run the workflow manually, GitHub Actions builds the macOS DMG and the Windows ZIP. The resulting artifacts are available for download from the workflow run.
 codex/distribute-app-for-windows-and-macos-without-fees
 
 

--- a/generate_qr_badges_final.py
+++ b/generate_qr_badges_final.py
@@ -1,8 +1,8 @@
 #!/usr/bin/env python3
-# v3.6.1-postfix — logos embedded as Base64
+# v3.6.2 — logos embedded as Base64
 
 """
-generate_qr_badges_final.py v3.6.1-postfix
+generate_qr_badges_final.py v3.6.2
 
 This version embeds the two PNG assets (full GT logo and small GT mark)
 directly into the script (Base64). At runtime, they’re decoded via PIL and displayed.
@@ -604,7 +604,12 @@ def name_badges_fixed(file_path: Path, save_path: Path, cfg: dict = DEFAULT_CONF
 
             group = safe_str(rec.get('Group Number', '')).strip()
             pronouns = safe_str(rec.get('Pronouns', '')).strip()
-            gp_text = ' – '.join(filter(None, [group, pronouns]))
+            gp_parts = []
+            if group:
+                gp_parts.append(f"Group: {group}")
+            if pronouns:
+                gp_parts.append(pronouns)
+            gp_text = ' – '.join(gp_parts)
             if gp_text:
                 add_centered_paragraph(gp_text, font_size=11)
 

--- a/version.txt
+++ b/version.txt
@@ -1,1 +1,1 @@
-FileVersion=3.6.1-postfix
+FileVersion=3.6.2


### PR DESCRIPTION
## Summary
- show Group Number inline with pronouns in the student badge
- bump version to 3.6.2 for new release
- fix NameError by ensuring group text is built before display

## Testing
- `python3 -m py_compile generate_qr_badges_final.py`


------
https://chatgpt.com/codex/tasks/task_e_685581c0d2688332a35bb42f31426f0d