### PR TITLE
Add Group alias support

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ Double-click **QR Badges.app** to launch.
 ## Usage
 
 1. **Select your CSV**
-   Must have columns `Preferred,Last,Code,group` (or `Group Number` for the group ID).
+   Must have columns `Preferred,Last,Code,group` (or `Group` or `Group Number` for the group ID).
 
 
 2. **Generate & Open**  

--- a/generate_qr_badges_final.py
+++ b/generate_qr_badges_final.py
@@ -127,8 +127,8 @@ REQUIRED_CSV_COLUMNS = [
     'group'
 ]
 
-# Accept either "group" or "Group Number" in the input CSV
-GROUP_COLUMN_ALIASES = ['group', 'Group Number']
+# Accept "group", "Group", or "Group Number" in the input CSV
+GROUP_COLUMN_ALIASES = ['group', 'Group', 'Group Number']
 
 
 def _choose_font(root):
@@ -236,7 +236,7 @@ def load_records(file_path: Path):
         logging.exception('Failed to read CSV.')
         sys.exit(1)
 
-    # Check required columns, allowing either 'group' or 'Group Number'
+    # Check required columns, allowing 'group', 'Group', or 'Group Number'
     missing = [col for col in REQUIRED_CSV_COLUMNS if col != 'group' and col not in df.columns]
 
     if not any(alias in df.columns for alias in GROUP_COLUMN_ALIASES):


### PR DESCRIPTION
## Summary
- update comment and alias list to allow more column names
- document that `Group` is also a valid column name

## Testing
- `python -m py_compile generate_qr_badges_final.py`

------
https://chatgpt.com/codex/tasks/task_e_685864e608448332bcbe51d8ae3ddc44