### PR TITLE
Update documentation and version

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,7 +1,6 @@
 MIT License
-codex/distribute-app-for-windows-and-macos-without-fees
-main
-Copyright (c) 2025 R. Clark Myers, M.Ed.
+
+Copyright (c) 2026 R. Clark Myers, M.Ed.
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal
 in the Software without restriction, including without limitation the rights

--- a/QR_Badges_mac.spec
+++ b/QR_Badges_mac.spec
@@ -50,7 +50,7 @@ app = BUNDLE(
     icon='AppIcon.icns',
     bundle_identifier='com.example.qrbadges',
     info_plist={
-        'CFBundleShortVersionString': '3.6.2',
-        'CFBundleVersion': '3.6.2',
+        'CFBundleShortVersionString': '3.7.0',
+        'CFBundleVersion': '3.7.0',
     }
 )

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ Double-click **QR Badges.app** to launch.
 
 ## Version
 
-Current app version: **3.6.2**
+Current app version: **3.7.0**
 
 ## Updating
 
@@ -89,15 +89,10 @@ Each build produces a standalone application bundle. macOS users can create a DM
 
 ## GitHub Actions Build
 
-A workflow file at `.github/workflows/build.yml` automates these steps. When you push a tag (e.g. `v3.6.2`) or run the workflow manually, GitHub Actions builds the macOS DMG and the Windows ZIP. The resulting artifacts are available for download from the workflow run.
-codex/distribute-app-for-windows-and-macos-without-fees
-
+A workflow file at `.github/workflows/build.yml` automates these steps. When you push a tag (e.g. `v3.7.0`) or run the workflow manually, GitHub Actions builds the macOS DMG and the Windows ZIP. The resulting artifacts are available for download from the workflow run.
 
 ---
- main
 
-
----
 *Developed by R. Clark Myers, M.Ed.*
 *Contact: rmyers66@gatech.edu*
 

--- a/generate_qr_badges_final.py
+++ b/generate_qr_badges_final.py
@@ -1,8 +1,8 @@
 #!/usr/bin/env python3
-# v3.6.2 — logos embedded as Base64
+# v3.7.0 — logos embedded as Base64
 
 """
-generate_qr_badges_final.py v3.6.2
+generate_qr_badges_final.py v3.7.0
 
 This version embeds the two PNG assets (full GT logo and small GT mark)
 directly into the script (Base64). At runtime, they’re decoded via PIL and displayed.

--- a/version.txt
+++ b/version.txt
@@ -1,1 +1,1 @@
-FileVersion=3.6.2
+FileVersion=3.7.0


### PR DESCRIPTION
## Summary
- bump app version to 3.7.0
- clean up README formatting and update version references
- refresh license year and remove stray lines

## Testing
- `python3 -m py_compile generate_qr_badges_final.py`

------
https://chatgpt.com/codex/tasks/task_e_6866992c29fc8332a58bf0ed7b11f685